### PR TITLE
test(dependencies-hierarchy): add test for package at different depths

### DIFF
--- a/__fixtures__/with-dep-at-different-depths/package.json
+++ b/__fixtures__/with-dep-at-different-depths/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "with-dep-at-different-depths",
+  "version": "0.0.0",
+  "dependencies": {
+    "glob": "^6.0.4"
+  }
+}

--- a/__fixtures__/with-dep-at-different-depths/pnpm-lock.yaml
+++ b/__fixtures__/with-dep-at-different-depths/pnpm-lock.yaml
@@ -1,0 +1,66 @@
+lockfileVersion: 5.4
+
+specifiers:
+  glob: ^6.0.4
+
+dependencies:
+  glob: 6.0.4
+
+packages:
+
+  /balanced-match/1.0.0:
+    resolution: {integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=}
+    dev: false
+
+  /brace-expansion/1.1.8:
+    resolution: {integrity: sha1-wHshHHyVLsH479Uad+8NHTmQopI=}
+    dependencies:
+      balanced-match: 1.0.0
+      concat-map: 0.0.1
+    dev: false
+
+  /concat-map/0.0.1:
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    dev: false
+
+  /glob/6.0.4:
+    resolution: {integrity: sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=}
+    dependencies:
+      inflight: 1.0.6
+      inherits: 2.0.3
+      minimatch: 3.0.4
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: false
+
+  /inflight/1.0.6:
+    resolution: {integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=}
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+    dev: false
+
+  /inherits/2.0.3:
+    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    dev: false
+
+  /minimatch/3.0.4:
+    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+    dependencies:
+      brace-expansion: 1.1.8
+    dev: false
+
+  /once/1.4.0:
+    resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
+    dependencies:
+      wrappy: 1.0.2
+    dev: false
+
+  /path-is-absolute/1.0.1:
+    resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /wrappy/1.0.2:
+    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    dev: false


### PR DESCRIPTION
Creating a PR and immediately closing to preserve changes. This test was rewritten in a later version of https://github.com/pnpm/pnpm/pull/5817. It was replaced with a unit test that's easier to work with.