### PR TITLE
pnpm dedupe --check: iteration 1

### DIFF
--- a/cli/default-reporter/package.json
+++ b/cli/default-reporter/package.json
@@ -36,6 +36,7 @@
     "@pnpm/config": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/error": "workspace:*",
+    "@pnpm/render-dedupe-check-issues": "workspace:*",
     "@pnpm/render-peer-issues": "workspace:*",
     "@pnpm/types": "workspace:*",
     "ansi-diff": "^1.1.1",

--- a/cli/default-reporter/src/reportError.ts
+++ b/cli/default-reporter/src/reportError.ts
@@ -2,7 +2,8 @@ import { type Config } from '@pnpm/config'
 import { type Log } from '@pnpm/core-loggers'
 import { type PnpmError } from '@pnpm/error'
 import { renderPeerIssues } from '@pnpm/render-peer-issues'
-import { type PeerDependencyIssuesByProjects } from '@pnpm/types'
+import { renderDedupeCheckIssues } from '@pnpm/render-dedupe-check-issues'
+import { type DedupeCheckIssues, type PeerDependencyIssuesByProjects } from '@pnpm/types'
 import chalk from 'chalk'
 import equals from 'ramda/src/equals'
 import StackTracey from 'stacktracey'
@@ -66,6 +67,8 @@ function getErrorInfo (logObj: Log, config?: Config): {
       return reportEngineError(logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
     case 'ERR_PNPM_PEER_DEP_ISSUES':
       return reportPeerDependencyIssuesError(err, logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+    case 'ERR_PNPM_DEDUPE_CHECK_ISSUES':
+      return reportDedupeCheckIssuesError(err, logObj as any) // eslint-disable-line @typescript-eslint/no-explicit-any
     case 'ERR_PNPM_FETCH_401':
     case 'ERR_PNPM_FETCH_403':
       return reportAuthError(err, logObj as any, config) // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -413,4 +416,11 @@ ${hints.map((hint) => `hint: ${hint}`).join('\n')}
 function getHasMissingPeers (issuesByProjects: PeerDependencyIssuesByProjects) {
   return Object.values(issuesByProjects)
     .some((issues) => Object.values(issues.missing).flat().some(({ optional }) => !optional))
+}
+
+function reportDedupeCheckIssuesError (err: Error, msg: { dedupeCheckIssues: DedupeCheckIssues }) {
+  return {
+    title: err.message,
+    body: renderDedupeCheckIssues(msg.dedupeCheckIssues),
+  }
 }

--- a/cli/default-reporter/tsconfig.json
+++ b/cli/default-reporter/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../packages/error"
     },
     {
+      "path": "../../packages/render-dedupe-check-issues"
+    },
+    {
       "path": "../../packages/render-peer-issues"
     },
     {

--- a/packages/core-loggers/src/dedupeCheckIssues.ts
+++ b/packages/core-loggers/src/dedupeCheckIssues.ts
@@ -1,0 +1,16 @@
+import {
+  type LogBase,
+  type Logger,
+  logger,
+} from '@pnpm/logger'
+import { type DedupeCheckIssues } from '@pnpm/types'
+
+export const dedupeCheckIssuesLogger = logger('dedupe-check-issues') as Logger<DedupeCheckIssuesMessage>
+
+export interface DedupeCheckIssuesMessage {
+  readonly dedupeCheckIssues: DedupeCheckIssues
+}
+
+export type DedupeCheckIssuesLog = { name: 'pnpm:dedupe-check-issues' } & LogBase & DedupeCheckIssuesMessage
+
+// This file may not be required.

--- a/packages/render-dedupe-check-issues/README.md
+++ b/packages/render-dedupe-check-issues/README.md
@@ -1,0 +1,13 @@
+# @pnpm/render-dedupe-check-issues
+
+> Visualizes "pnpm dedupe --check" issues
+
+## Installation
+
+```
+pnpm add @pnpm/render-dedupe-check-issues
+```
+
+## License
+
+[MIT](LICENSE)

--- a/packages/render-dedupe-check-issues/jest.config.js
+++ b/packages/render-dedupe-check-issues/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest.config')

--- a/packages/render-dedupe-check-issues/package.json
+++ b/packages/render-dedupe-check-issues/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@pnpm/render-dedupe-check-issues",
+  "description": "Visualize pnpm dedupe --check issues.",
+  "private": true,
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "keywords": [
+    "pnpm8"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.14"
+  },
+  "repository": "https://github.com/pnpm/pnpm/blob/main/packages/render-dedupe-check-issues",
+  "scripts": {
+    "_test": "jest",
+    "test": "pnpm run compile && pnpm run _test",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "prepublishOnly": "pnpm run compile",
+    "compile": "tsc --build && pnpm run lint --fix"
+  },
+  "homepage": "https://github.com/pnpm/pnpm/blob/main/packages/render-dedupe-check-issues#readme",
+  "funding": "https://opencollective.com/pnpm",
+  "dependencies": {
+    "@pnpm/types": "workspace:*",
+    "archy": "^1.0.0",
+    "chalk": "^4.1.2"
+  },
+  "devDependencies": {
+    "@pnpm/render-dedupe-check-issues": "workspace:*",
+    "@types/archy": "0.0.32",
+    "strip-ansi": "^6.0.1"
+  },
+  "exports": {
+    ".": "./lib/index.js"
+  }
+}

--- a/packages/render-dedupe-check-issues/src/index.ts
+++ b/packages/render-dedupe-check-issues/src/index.ts
@@ -1,0 +1,45 @@
+import { type ResolutionChange, type DedupeCheckIssue, type DedupeCheckIssues } from '@pnpm/types'
+import archy from 'archy'
+import chalk from 'chalk'
+
+export function renderDedupeCheckIssues (dedupeCheckIssues: DedupeCheckIssues) {
+  function toArchy (name: string, issue: DedupeCheckIssue): archy.Data {
+    switch (issue.type) {
+    case 'added':
+      return { label: `${chalk.green('+')} ${name}` }
+    case 'deleted':
+      return { label: `${chalk.red('-')} ${name}` }
+    case 'updated':
+      return {
+        label: name,
+        nodes: Object.entries(issue.updates)
+          .map(([alias, change]) => toArchyResolution(alias, change)),
+      }
+    }
+  }
+
+  function toArchyResolution (alias: string, change: ResolutionChange) {
+    switch (change.type) {
+    case 'added':
+      return { label: `${chalk.green('+')} ${alias} ${chalk.dim(change.next)}` }
+    case 'deleted':
+      return { label: `${chalk.red('-')} ${alias} ${chalk.dim(change.prev)}` }
+    case 'updated':
+      return { label: `${alias} ${chalk.red(change.prev)} ${chalk.dim('→')} ${chalk.green(change.next)}` }
+    }
+  }
+
+  const data: archy.Data = {
+    label: 'importers',
+    nodes: Object.entries(dedupeCheckIssues.importerIssuesByImporterId)
+      .map(([importerId, issue]) => toArchy(importerId, issue)),
+  }
+
+  const packagesData: archy.Data = {
+    label: 'packages',
+    nodes: Object.entries(dedupeCheckIssues.packageIssuesByDepPath)
+      .map(([id, issue]) => toArchy(id, issue)),
+  }
+
+  return archy(data) + '\n' + archy(packagesData)
+}

--- a/packages/render-dedupe-check-issues/tsconfig.json
+++ b/packages/render-dedupe-check-issues/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../types"
+    }
+  ],
+  "composite": true
+}

--- a/packages/render-dedupe-check-issues/tsconfig.lint.json
+++ b/packages/render-dedupe-check-issues/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/packages/types/src/dedupeCheckIssues.ts
+++ b/packages/types/src/dedupeCheckIssues.ts
@@ -1,0 +1,42 @@
+export interface DedupeCheckIssues {
+  readonly importerIssuesByImporterId: Record<string, DedupeCheckIssue>
+  readonly packageIssuesByDepPath: Record<string, DedupeCheckIssue>
+}
+
+export type DedupeCheckIssue =
+  DedupeCheckIssueAdded |
+  DedupeCheckIssueDeleted |
+  DedupeCheckIssueUpdated
+
+export type ResolutionChangesByAlias = Record<string, ResolutionChange>
+
+export interface DedupeCheckIssueAdded {
+  readonly type: 'added'
+}
+
+export interface DedupeCheckIssueDeleted {
+  readonly type: 'deleted'
+}
+
+export interface DedupeCheckIssueUpdated {
+  readonly type: 'updated'
+  readonly updates: ResolutionChangesByAlias
+}
+
+export type ResolutionChange = ResolutionAdded | ResolutionDeleted | ResolutionUpdated
+
+export interface ResolutionAdded {
+  readonly type: 'added'
+  readonly next: string
+}
+
+export interface ResolutionDeleted {
+  readonly type: 'deleted'
+  readonly prev: string
+}
+
+export interface ResolutionUpdated {
+  readonly type: 'updated'
+  readonly prev: string
+  readonly next: string
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
+export * from './dedupeCheckIssues'
 export * from './misc'
 export * from './options'
 export * from './package'

--- a/pkg-manager/core/src/install/extendInstallOptions.ts
+++ b/pkg-manager/core/src/install/extendInstallOptions.ts
@@ -42,6 +42,7 @@ export interface StrictInstallOptions {
   ignorePackageManifest: boolean
   preferFrozenLockfile: boolean
   saveWorkspaceProtocol: boolean | 'rolling'
+  lockfileCheck?: (prev: Lockfile, next: Lockfile) => void
   lockfileIncludeTarballUrl: boolean
   preferWorkspacePackages: boolean
   preserveWorkspaceProtocol: boolean

--- a/pkg-manager/core/src/install/index.ts
+++ b/pkg-manager/core/src/install/index.ts
@@ -65,6 +65,7 @@ import pLimit from 'p-limit'
 import pMapValues from 'p-map-values'
 import flatten from 'ramda/src/flatten'
 import mapValues from 'ramda/src/map'
+import clone from 'ramda/src/clone'
 import equals from 'ramda/src/equals'
 import isEmpty from 'ramda/src/isEmpty'
 import pickBy from 'ramda/src/pickBy'
@@ -598,6 +599,7 @@ Note that in CI environments, this setting is enabled by default.`,
       ctx.existsWantedLockfile && !ctx.existsCurrentLockfile ||
       !ctx.currentLockfileIsUpToDate
     )
+
     const result = await installInContext(projectsToInstall, ctx, {
       ...opts,
       currentLockfileIsUpToDate: !ctx.existsWantedLockfile || ctx.currentLockfileIsUpToDate,
@@ -801,6 +803,19 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     })
   }
 
+  // The wanted lockfile is mutated during installation. To compare changes, a
+  // deep copy before installation is needed. This copy should represent the
+  // original wanted lockfile on disk as close as possible.
+  //
+  // This object can be quite large. Intentionally avoiding an expensive copy
+  // if no lockfileCheck option was passed in.
+  const originalLockfileForCheck = opts.lockfileCheck != null
+    ? clone(ctx.wantedLockfile)
+    : null
+
+  // Aliasing for clarity in boolean expressions.
+  const isInstallationOnlyForLockfileCheck = opts.lockfileCheck != null
+
   ctx.wantedLockfile.importers = ctx.wantedLockfile.importers || {}
   for (const { id } of projects) {
     if (!ctx.wantedLockfile.importers[id]) {
@@ -965,7 +980,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     useGitBranchLockfile: opts.useGitBranchLockfile,
     mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
   }
-  if (!opts.lockfileOnly && opts.enableModulesDir) {
+  if (!opts.lockfileOnly && !isInstallationOnlyForLockfileCheck && opts.enableModulesDir) {
     const result = await linkPackages(
       projects,
       dependenciesGraph,
@@ -1199,7 +1214,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     }
   } else {
     await finishLockfileUpdates()
-    if (opts.useLockfile) {
+    if (opts.useLockfile && !isInstallationOnlyForLockfileCheck) {
       await writeWantedLockfile(ctx.lockfileDir, newLockfile, lockfileOpts)
     }
 
@@ -1222,6 +1237,14 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
     lockfileDir: opts.lockfileDir,
     strictPeerDependencies: opts.strictPeerDependencies,
   })
+
+  // Similar to the sequencing for when the original wanted lockfile is
+  // copied, the new lockfile passed here should be as close as possible to
+  // what will eventually be written to disk. Ex: peers should be resolved,
+  // the afterAllResolved hook has been applied, etc.
+  if (originalLockfileForCheck != null) {
+    opts.lockfileCheck?.(originalLockfileForCheck, newLockfile)
+  }
 
   return {
     newLockfile,

--- a/pkg-manager/plugin-commands-installation/src/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/src/dedupe.ts
@@ -1,7 +1,8 @@
 import { docsUrl } from '@pnpm/cli-utils'
 import { UNIVERSAL_OPTIONS } from '@pnpm/common-cli-options-help'
 import renderHelp from 'render-help'
-import * as install from './install'
+import { type InstallCommandOptions } from './install'
+import { installDeps } from './installDeps'
 
 export const rcOptionsTypes = cliOptionsTypes
 
@@ -27,11 +28,16 @@ export function help () {
   })
 }
 
-export async function handler (
-  opts: install.InstallCommandOptions
-) {
-  return install.handler({
+export async function handler (opts: InstallCommandOptions) {
+  const include = {
+    dependencies: opts.production !== false,
+    devDependencies: opts.dev !== false,
+    optionalDependencies: opts.optional !== false,
+  }
+  return installDeps({
     ...opts,
     dedupe: true,
-  })
+    include,
+    includeDirect: include,
+  }, [])
 }

--- a/pkg-manager/plugin-commands-installation/src/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/src/dedupe.ts
@@ -3,6 +3,7 @@ import { UNIVERSAL_OPTIONS } from '@pnpm/common-cli-options-help'
 import renderHelp from 'render-help'
 import { type InstallCommandOptions } from './install'
 import { installDeps } from './installDeps'
+import { dedupeDiffCheck } from './dedupeDiffCheck'
 
 export function rcOptionsTypes () {
   return {}
@@ -52,5 +53,6 @@ export async function handler (opts: DedupeCommandOptions) {
     dedupe: true,
     include,
     includeDirect: include,
+    lockfileCheck: opts.check ? dedupeDiffCheck : undefined,
   }, [])
 }

--- a/pkg-manager/plugin-commands-installation/src/dedupe.ts
+++ b/pkg-manager/plugin-commands-installation/src/dedupe.ts
@@ -4,10 +4,15 @@ import renderHelp from 'render-help'
 import { type InstallCommandOptions } from './install'
 import { installDeps } from './installDeps'
 
-export const rcOptionsTypes = cliOptionsTypes
+export function rcOptionsTypes () {
+  return {}
+}
 
 export function cliOptionsTypes () {
-  return {}
+  return {
+    ...rcOptionsTypes(),
+    check: Boolean,
+  }
 }
 
 export const commandNames = ['dedupe']
@@ -20,6 +25,10 @@ export function help () {
         title: 'Options',
         list: [
           ...UNIVERSAL_OPTIONS,
+          {
+            description: 'Check if running dedupe would result in changes without installing packages or editing the lockfile. Exits with a non-zero status code if changes are possible.',
+            name: '--check',
+          },
         ],
       },
     ],
@@ -28,7 +37,11 @@ export function help () {
   })
 }
 
-export async function handler (opts: InstallCommandOptions) {
+export interface DedupeCommandOptions extends InstallCommandOptions {
+  readonly check?: boolean
+}
+
+export async function handler (opts: DedupeCommandOptions) {
   const include = {
     dependencies: opts.production !== false,
     devDependencies: opts.dev !== false,

--- a/pkg-manager/plugin-commands-installation/src/dedupeDiffCheck.ts
+++ b/pkg-manager/plugin-commands-installation/src/dedupeDiffCheck.ts
@@ -1,0 +1,114 @@
+import { PnpmError } from '@pnpm/error'
+import { type ResolvedDependencies, type Lockfile } from '@pnpm/lockfile-types'
+import {
+  DEPENDENCIES_FIELDS,
+  type ResolutionChangesByAlias,
+  type DedupeCheckIssue,
+  type DedupeCheckIssues,
+} from '@pnpm/types'
+
+export function dedupeDiffCheck (prev: Lockfile, next: Lockfile): void {
+  function getImporterIssuesByImporterId () {
+    const importerIssuesByImporterId: Record<string, DedupeCheckIssue> = {}
+
+    for (const [importerId, prevSnapshot] of Object.entries(prev.importers ?? {})) {
+      const nextSnapshot = next.importers[importerId]
+
+      if (nextSnapshot == null) {
+        importerIssuesByImporterId[importerId] = { type: 'deleted' }
+        continue
+      }
+
+      const updates = DEPENDENCIES_FIELDS.reduce((acc: ResolutionChangesByAlias, dependencyField) => ({
+        ...acc,
+        ...getResolutionUpdates(prevSnapshot[dependencyField] ?? {}, nextSnapshot[dependencyField] ?? {}),
+      }), {})
+
+      if (Object.keys(updates).length > 0) {
+        importerIssuesByImporterId[importerId] = { type: 'updated', updates }
+      }
+    }
+
+    const newImporterIds = Object.keys(next.importers ?? {})
+      .filter(importerId => prev.importers[importerId] == null)
+    for (const added of newImporterIds) {
+      importerIssuesByImporterId[added] = { type: 'added' }
+    }
+
+    return importerIssuesByImporterId
+  }
+
+  function getPackageIssuesByDepPath () {
+    const packageIssuesByDepPath: Record<string, DedupeCheckIssue> = {}
+
+    for (const [depPath, prevSnapshot] of Object.entries(prev.packages ?? {})) {
+      const nextSnapshot = next.packages?.[depPath]
+
+      if (nextSnapshot == null) {
+        packageIssuesByDepPath[depPath] = { type: 'deleted' }
+        continue
+      }
+
+      const updates = (['dependencies', 'optionalDependencies'] as const)
+        .reduce((acc: ResolutionChangesByAlias, dependencyField) => ({
+          ...acc,
+          ...getResolutionUpdates(prevSnapshot[dependencyField] ?? {}, nextSnapshot?.[dependencyField] ?? {}),
+        }), {})
+
+      if (Object.keys(updates).length > 0) {
+        packageIssuesByDepPath[depPath] = { type: 'updated', updates }
+      }
+    }
+
+    const newDepPaths = Object.keys(next.packages ?? {})
+      .filter(depPath => prev.packages?.[depPath] == null)
+    for (const added of newDepPaths) {
+      packageIssuesByDepPath[added] = { type: 'added' }
+    }
+
+    return packageIssuesByDepPath
+  }
+
+  function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDependencies): ResolutionChangesByAlias {
+    const updates: ResolutionChangesByAlias = {}
+
+    for (const [alias, prevResolution] of Object.entries(prev ?? {})) {
+      const nextResolution = next?.[alias]
+
+      if (prevResolution === nextResolution) {
+        continue
+      }
+
+      updates[alias] = nextResolution == null
+        ? { type: 'deleted', prev: prevResolution }
+        : { type: 'updated', prev: prevResolution, next: nextResolution }
+    }
+
+    const newAliases = Object.entries(next ?? {})
+      .filter(([alias]) => prev?.[alias] == null)
+    for (const [alias, nextResolution] of newAliases) {
+      updates[alias] = { type: 'added', next: nextResolution }
+    }
+
+    return updates
+  }
+
+  const issues: DedupeCheckIssues = {
+    importerIssuesByImporterId: getImporterIssuesByImporterId(),
+    packageIssuesByDepPath: getPackageIssuesByDepPath(),
+  }
+
+  const changesCount =
+    Object.keys(issues.importerIssuesByImporterId).length +
+    Object.keys(issues.packageIssuesByDepPath).length
+
+  if (changesCount > 0) {
+    throw new DedupeCheckIssuesError(issues)
+  }
+}
+
+export class DedupeCheckIssuesError extends PnpmError {
+  constructor (public dedupeCheckIssues: DedupeCheckIssues) {
+    super('DEDUPE_CHECK_ISSUES', 'Dedupe --check found changes to the lockfile')
+  }
+}

--- a/pkg-manager/plugin-commands-installation/src/install.ts
+++ b/pkg-manager/plugin-commands-installation/src/install.ts
@@ -296,7 +296,6 @@ export type InstallCommandOptions = Pick<Config,
   pruneDirectDependencies?: boolean
   pruneStore?: boolean
   recursive?: boolean
-  dedupe?: boolean
   saveLockfile?: boolean
   workspace?: boolean
   includeOnlyPackageFiles?: boolean

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -7,6 +7,7 @@ import { type Config } from '@pnpm/config'
 import { PnpmError } from '@pnpm/error'
 import { filterPkgsBySelectorObjects } from '@pnpm/filter-workspace-packages'
 import { arrayOfWorkspacePackagesToMap, findWorkspacePackages } from '@pnpm/find-workspace-packages'
+import { type Lockfile } from '@pnpm/lockfile-types'
 import { rebuildProjects } from '@pnpm/plugin-commands-rebuild'
 import { createOrConnectStoreController, type CreateStoreControllerOptions } from '@pnpm/store-connection-manager'
 import { type IncludedDependencies, type Project, type ProjectsGraph } from '@pnpm/types'
@@ -88,6 +89,17 @@ export type InstallDepsOptions = Pick<Config,
   include?: IncludedDependencies
   includeDirect?: IncludedDependencies
   latest?: boolean
+  /**
+   * If specified, the installation will only be performed for comparison of the
+   * wanted lockfile. The wanted lockfile will not be updated on disk and no
+   * modules will be linked.
+   *
+   * The given callback is passed the wanted lockfile before installation and
+   * after. This allows functions to reasonably determine whether the wanted
+   * lockfile will change on disk after installation. The lockfile arguments
+   * passed to this callback should not be mutated.
+   */
+  lockfileCheck?: (prev: Lockfile, next: Lockfile) => void
   update?: boolean
   updateMatching?: (pkgName: string) => boolean
   updatePackageManifest?: boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,6 +439,9 @@ importers:
       '@pnpm/logger':
         specifier: ^5.0.0
         version: 5.0.0
+      '@pnpm/render-dedupe-check-issues':
+        specifier: workspace:*
+        version: link:../../packages/render-dedupe-check-issues
       '@pnpm/render-peer-issues':
         specifier: workspace:*
         version: link:../../packages/render-peer-issues
@@ -2442,6 +2445,28 @@ importers:
       '@pnpm/prepare':
         specifier: workspace:*
         version: link:../../__utils__/prepare
+
+  packages/render-dedupe-check-issues:
+    dependencies:
+      '@pnpm/types':
+        specifier: workspace:*
+        version: link:../types
+      archy:
+        specifier: ^1.0.0
+        version: 1.0.0
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+    devDependencies:
+      '@pnpm/render-dedupe-check-issues':
+        specifier: workspace:*
+        version: 'link:'
+      '@types/archy':
+        specifier: 0.0.32
+        version: 0.0.32
+      strip-ansi:
+        specifier: ^6.0.1
+        version: 6.0.1
 
   packages/render-peer-issues:
     dependencies:
@@ -8795,7 +8820,7 @@ packages:
   /@types/byline@4.2.33:
     resolution: {integrity: sha512-LJYez7wrWcJQQDknqZtrZuExMGP0IXmPl1rOOGDqLbu+H7UNNRfKNuSxCBcQMLH1EfjeWidLedC/hCc5dDfBog==}
     dependencies:
-      '@types/node': 18.15.11
+      '@types/node': 14.18.42
     dev: true
 
   /@types/cacheable-request@6.0.3:
@@ -13491,7 +13516,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.3.8
+      semver: 7.4.0
 
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}

--- a/pnpm/tsconfig.json
+++ b/pnpm/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": false,
     "declaration": false,
     "outDir": "lib",
-    "sourceMap": false,
+    "sourceMap": true,
     "rootDir": "src",
     "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0"


### PR DESCRIPTION
This is a version of `pnpm dedupe --check` that combines all changes. I'm switching gears to a different output format that splits new packages, deleted packages, and changed packages into different groups.

<img width="1067" alt="Screenshot 2023-04-15 at 2 10 45 PM" src="https://user-images.githubusercontent.com/906558/232246260-7aa9e348-56a7-4134-ab67-f9461677011d.png">

Opening as a PR and immediately closing to preserve changes.