### PR TITLE
refactor: add WorkspaceManifest to `@pnpm/config`

### DIFF
--- a/config/config/package.json
+++ b/config/config/package.json
@@ -41,6 +41,7 @@
     "@pnpm/pnpmfile": "workspace:*",
     "@pnpm/read-project-manifest": "workspace:*",
     "@pnpm/types": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*",
     "better-path-resolve": "1.0.0",
     "camelcase": "^6.3.0",
     "camelcase-keys": "^6.2.2",

--- a/config/config/src/Config.ts
+++ b/config/config/src/Config.ts
@@ -6,6 +6,7 @@ import {
   type SslConfig,
 } from '@pnpm/types'
 import type { Hooks } from '@pnpm/pnpmfile'
+import { type WorkspaceManifest } from '@pnpm/workspace.read-manifest'
 
 export type UniversalOptions = Pick<Config, 'color' | 'dir' | 'rawConfig' | 'rawLocalConfig'>
 
@@ -176,6 +177,7 @@ export interface Config {
   changedFilesIgnorePattern?: string[]
   rootProjectManifestDir: string
   rootProjectManifest?: ProjectManifest
+  workspaceManifest?: WorkspaceManifest
   userConfig: Record<string, string>
 
   globalconfig: string

--- a/config/config/src/index.ts
+++ b/config/config/src/index.ts
@@ -24,6 +24,7 @@ import {
   type UniversalOptions,
 } from './Config'
 import { getWorkspaceConcurrency } from './concurrency'
+import { readWorkspaceManifest } from '@pnpm/workspace.read-manifest'
 
 export { getOptionsFromRootManifest, type OptionsFromRootManifest } from './getOptionsFromRootManifest'
 export * from './readLocalConfig'
@@ -574,6 +575,10 @@ export async function getConfig (
   pnpmConfig.rootProjectManifest = await safeReadProjectManifestOnly(pnpmConfig.rootProjectManifestDir) ?? undefined
   if (pnpmConfig.rootProjectManifest?.workspaces?.length && !pnpmConfig.workspaceDir) {
     warnings.push('The "workspaces" field in package.json is not supported by pnpm. Create a "pnpm-workspace.yaml" file instead.')
+  }
+
+  if (pnpmConfig.workspaceDir != null) {
+    pnpmConfig.workspaceManifest = await readWorkspaceManifest(pnpmConfig.workspaceDir)
   }
 
   pnpmConfig.failedToLoadBuiltInConfig = failedToLoadBuiltInConfig

--- a/config/config/tsconfig.json
+++ b/config/config/tsconfig.json
@@ -34,6 +34,9 @@
       "path": "../../pkg-manifest/read-project-manifest"
     },
     {
+      "path": "../../workspace/read-manifest"
+    },
+    {
       "path": "../matcher"
     }
   ],

--- a/pkg-manager/plugin-commands-installation/src/import/index.ts
+++ b/pkg-manager/plugin-commands-installation/src/import/index.ts
@@ -101,6 +101,7 @@ export type ImportCommandOptions = Pick<Config,
 | 'sharedWorkspaceLockfile'
 | 'rootProjectManifest'
 | 'rootProjectManifestDir'
+| 'workspaceManifest'
 > & CreateStoreControllerOptions & Omit<InstallOptions, 'storeController' | 'lockfileOnly' | 'preferredVersions'>
 
 export async function handler (

--- a/pkg-manager/plugin-commands-installation/src/installDeps.ts
+++ b/pkg-manager/plugin-commands-installation/src/installDeps.ts
@@ -80,6 +80,7 @@ export type InstallDepsOptions = Pick<Config,
 | 'optional'
 | 'workspaceConcurrency'
 | 'workspaceDir'
+| 'workspaceManifest'
 | 'extraEnv'
 | 'ignoreWorkspaceCycles'
 | 'disallowWorkspaceCycles'

--- a/pkg-manager/plugin-commands-installation/src/link.ts
+++ b/pkg-manager/plugin-commands-installation/src/link.ts
@@ -43,6 +43,7 @@ type LinkOpts = CreateStoreControllerOptions & Pick<Config,
 | 'saveOptional'
 | 'saveProd'
 | 'workspaceDir'
+| 'workspaceManifest'
 | 'sharedWorkspaceLockfile'
 > & Partial<Pick<Config, 'linkWorkspacePackages'>>
 

--- a/pkg-manager/plugin-commands-installation/src/remove.ts
+++ b/pkg-manager/plugin-commands-installation/src/remove.ts
@@ -147,6 +147,7 @@ export async function handler (
   | 'saveProd'
   | 'selectedProjectsGraph'
   | 'workspaceDir'
+  | 'workspaceManifest'
   | 'sharedWorkspaceLockfile'
   > & {
     recursive?: boolean

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,9 @@ importers:
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../../workspace/read-manifest
       better-path-resolve:
         specifier: 1.0.0
         version: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6413,6 +6413,9 @@ importers:
       '@pnpm/workspace.pkgs-graph':
         specifier: workspace:*
         version: link:../pkgs-graph
+      '@pnpm/workspace.read-manifest':
+        specifier: workspace:*
+        version: link:../read-manifest
       execa:
         specifier: npm:safe-execa@0.1.2
         version: safe-execa@0.1.2

--- a/pnpm/src/main.ts
+++ b/pnpm/src/main.ts
@@ -204,6 +204,7 @@ export async function main (inputArgv: string[]): Promise<void> {
       linkWorkspacePackages: !!config.linkWorkspacePackages,
       prefix: process.cwd(),
       workspaceDir: wsDir,
+      workspaceManifest: config.workspaceManifest,
       testPattern: config.testPattern,
       changedFilesIgnorePattern: config.changedFilesIgnorePattern,
       useGlobDirFiltering: !config.legacyDirFiltering,

--- a/workspace/filter-workspace-packages/package.json
+++ b/workspace/filter-workspace-packages/package.json
@@ -33,6 +33,7 @@
     "@pnpm/matcher": "workspace:*",
     "@pnpm/workspace.find-packages": "workspace:*",
     "@pnpm/workspace.pkgs-graph": "workspace:*",
+    "@pnpm/workspace.read-manifest": "workspace:*",
     "execa": "npm:safe-execa@0.1.2",
     "find-up": "^5.0.0",
     "is-subdir": "^1.2.0",

--- a/workspace/filter-workspace-packages/src/index.ts
+++ b/workspace/filter-workspace-packages/src/index.ts
@@ -9,6 +9,7 @@ import pick from 'ramda/src/pick'
 import * as micromatch from 'micromatch'
 import { getChangedPackages } from './getChangedPackages'
 import { parsePackageSelector, type PackageSelector } from './parsePackageSelector'
+import { type WorkspaceManifest } from '@pnpm/workspace.read-manifest'
 
 export { parsePackageSelector, type PackageSelector }
 
@@ -81,6 +82,7 @@ export async function filterPackagesFromDir (
     nodeVersion?: string
     patterns: string[]
     supportedArchitectures?: SupportedArchitectures
+    workspaceManifest?: WorkspaceManifest
   }
 ): Promise<FilterPackagesFromDirResult> {
   const allProjects = await findWorkspacePackages(workspaceDir, {
@@ -89,6 +91,7 @@ export async function filterPackagesFromDir (
     sharedWorkspaceLockfile: opts.sharedWorkspaceLockfile,
     nodeVersion: opts.nodeVersion,
     supportedArchitectures: opts.supportedArchitectures,
+    workspaceManifest: opts.workspaceManifest,
   })
   return {
     allProjects,

--- a/workspace/filter-workspace-packages/tsconfig.json
+++ b/workspace/filter-workspace-packages/tsconfig.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../pkgs-graph"
+    },
+    {
+      "path": "../read-manifest"
     }
   ],
   "composite": true


### PR DESCRIPTION
This is a work in progress PR to make sure `@pnpm/config` reads the workspace manifest and passes it to `@pnpm/workspace.find-packages` correctly.